### PR TITLE
Fix link to 'Icon' component in sidebar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ sidebar:
       - name: Divider
         url: /components/divider
       - name: Icon
-        url: /components/Icon
+        url: /components/icon
       - name: Icon Button
         url: /components/icon-button
       - name: List


### PR DESCRIPTION
The link to the page for the 'Icon' component seems to be broken in the production documentation website. This looks to be due to an uppercase 'i' in the URL for that component. I've changed it to a lowercase 'i' to match the URLs for the other components.
