### PR TITLE
Update installation instructions (matching changes to README in src

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -9,9 +9,13 @@ Install the library:
 npm i react-native-material-design --save
 ```
 
-Copy the `MaterialIcons` font file from [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons#android) to your local working directory:
+Follow the [Android installation instructions](https://github.com/oblador/react-native-vector-icons#android) on the [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) library, which consists of adding the following to your `./android/app/build.gradle`:
 
-`./node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf` -> `./android/app/src/main/assets/fonts`.
+```gradle
+apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
+```
+
+_Note: It's possible that the instructions on the react-native-vector-icons page differ from what is above. If that's the case, follow those instructions, and please file an issue with us to update it here._
 
 Import any required components into your project:
 


### PR DESCRIPTION
repo)
- Replace "copy font files" step with extending the build.gradle file with
  the fonts.gradle file in react-native-vector-icons
- Allows for successful builds using react-native >0.18
